### PR TITLE
🔧 fix: fix email constraint & password return

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -19,7 +19,7 @@ export class UserController {
 
   @Get()
   async findOne(@GetUser() tokenPayload: TokenPayload) {
-    return await this.userService.FindUser(tokenPayload.userEmail);
+    return await this.userService.findOne(tokenPayload.userId);
   }
 
   @Patch()
@@ -27,11 +27,11 @@ export class UserController {
     @Body() updateUserDto: UpdateUserDto,
     @GetUser() tokenPayload: TokenPayload,
   ) {
-    return await this.userService.update(tokenPayload.userEmail, updateUserDto);
+    return await this.userService.update(tokenPayload.userId, updateUserDto);
   }
 
   @Delete()
   async remove(@GetUser() tokenPayload: TokenPayload) {
-    return await this.userService.remove(tokenPayload.userEmail);
+    return await this.userService.remove(tokenPayload.userId);
   }
 }


### PR DESCRIPTION
Besides the issue fix, which in the create method in the user service, there isn't a verification to check if the provided email is already stored in the database.
Without this validation, if a user tries to create a user with a existent email in the database the server will crash.

I also added a findOne method that does the user search based on the id of the user which doesn't return the user password. 

I did it in this format because for the authentication we'll require a method that returns the password to validate the match between the signIn information and the database. 
However, for frontend needs from the user it isn't a good practice to expose sensitive information such as a password.